### PR TITLE
fix production mode problems by deferring webpack requires

### DIFF
--- a/bin/outriggerd
+++ b/bin/outriggerd
@@ -1,14 +1,8 @@
 #!/usr/bin/env node
 
 var _ = require('underscore');
-var path = require('path');
 var logSetup = require('./log-setup');
 var minimist = require('minimist');
-var webpack = require('webpack');
-var webpackDevMiddleware = require('webpack-dev-middleware');
-var webpackConfig = require('../webpack.config');
-var express = require('express');
-var app = new express();
 var JuttledService = require('../lib/service-juttled');
 
 var defaults = {

--- a/lib/app-router.js
+++ b/lib/app-router.js
@@ -1,15 +1,11 @@
 var fs = require('fs');
 var path = require('path');
 var express = require('express');
-var webpack = require('webpack');
-var webpackDevMiddleware = require('webpack-dev-middleware');
-var webpackConfig = require('../webpack.config');
 
 var DIST_DIR = 'dist';
 
 module.exports.init = function() {
     var router = express.Router();
-    var assetPath = webpackConfig.output.publicPath;
     var devMode;
 
     try {
@@ -21,6 +17,11 @@ module.exports.init = function() {
     }
 
     if (devMode) {
+        var webpack = require('webpack');
+        var webpackDevMiddleware = require('webpack-dev-middleware');
+        var webpackConfig = require('../webpack.config');
+        var assetPath = webpackConfig.output.publicPath;
+
         var compiler = webpack(webpackConfig);
         router.use(webpackDevMiddleware(compiler, {
             noInfo: true,
@@ -28,7 +29,7 @@ module.exports.init = function() {
         }));
     } else {
         // serve static assets from dist
-        router.use(assetPath, express.static(path.join(__dirname, '..', 'dist')));
+        router.use('/assets', express.static(path.join(__dirname, '..', 'dist')));
     }
 
     router.get('/run', function(req, res) {


### PR DESCRIPTION
Production mode installations where webpack doesn't exist were failing
to run because they still required webpack at the top level.

Fix this by deferring the requires inside the conditional check for
dev mode.