### PR TITLE
package.json: move packages out of devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "express": "^4.13.3",
     "express-ws": "^1.0.0-rc.2",
     "extendable-base": "^0.3.1",
+    "extract-text-webpack-plugin": "^0.9.1",
     "fast-url-parser": "^1.1.3",
     "fs-extra": "^0.26.2",
     "history": "^1.13.1",
@@ -51,6 +52,8 @@
     "request-promise": "^1.0.2",
     "underscore": "^1.8.3",
     "uuid": "1.4.1",
+    "webpack": "^1.12.6",
+    "webpack-dev-middleware": "^1.2.0",
     "ws": "^0.4.31"
   },
   "devDependencies": {
@@ -62,7 +65,6 @@
     "chai": "^3.4.1",
     "chakram": "^1.2.1",
     "css-loader": "^0.23.0",
-    "extract-text-webpack-plugin": "^0.9.1",
     "gulp": "^3.9.0",
     "gulp-jscs": "^3.0.2",
     "gulp-jshint": "^1.12.0",
@@ -74,9 +76,7 @@
     "rimraf": "^2.4.4",
     "sass-loader": "^3.1.1",
     "selenium-webdriver": "^2.48.2",
-    "style-loader": "^0.13.0",
-    "webpack": "^1.12.6",
-    "webpack-dev-middleware": "^1.2.0"
+    "style-loader": "^0.13.0"
   },
   "peerDependencies": {
     "juttle": "^0.1.0"


### PR DESCRIPTION
outriggerd needs them and otherwise fails (after following the README instructions of `npm install -g outrigger`