### PR TITLE
fix npm installation issues

### DIFF
--- a/log4js.json
+++ b/log4js.json
@@ -5,10 +5,6 @@
     "appenders": [
         {
             "type": "console"
-        },
-        {
-            "type": "file",
-            "filename": "log/demo.log"
         }
     ]
 }

--- a/package.json
+++ b/package.json
@@ -84,5 +84,17 @@
   "engines": {
     "node": ">=4.2.0",
     "npm": ">=2.14.7"
-  }
+  },
+  "files": [
+    "LICENSE",
+    "NOTICE",
+    "README.md",
+    "gulpfile.js",
+    "bin",
+    "dist",
+    "docs",
+    "lib",
+    "log4js.json",
+    "src"
+  ]
 }


### PR DESCRIPTION
Fix a few issues that occurred when running from the npm installation as opposed to from the source tree.

First, make sure to include the dist directory in the npm published package. This is a followup to the changes in #1 which fixed the require problem, but still failed to run because of the missing dist dependency.

Also fix the logic used to find the dist directory to be based on the file location and not the cwd from where outriggerd is run.

Second, address #4 by removing the default file appender from log4js since it depends on a `./log` directory existing in the cwd which is not necessarily the case.

