### PR TITLE
Clean up outrigger-client usage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ usage: [--port <port>] [--root <path>]
 ### outrigger-client
 
 ```
-usage: [--outrigger-juttle <hostname:port>] [--outrigger-app <hostname:port>] [--help] [COMMAND] [OPTIONS]
+usage: [--outriggerd <hostname:port>] [--help] [COMMAND] [OPTIONS]
    [COMMAND]: one of the following, with the following options:
          list_jobs [--job <job-id>]
          browser --path <path>
@@ -65,8 +65,7 @@ usage: [--outrigger-juttle <hostname:port>] [--outrigger-app <hostname:port>] [-
                                               Used by "browser".
        --job <job-id>:                        Job id.
                                               Used by "list_jobs".
-       --outrigger-juttle <hostname:port>:    Hostname/port of outrigger juttle server
-       --outrigger-app <hostname:port>:       Hostname/port of outrigger app server
+       --outriggerd <hostname:port>:          Hostname/port of outrigger juttle server
        --help:                                Print this help and exit
 ```
 

--- a/bin/outrigger-client
+++ b/bin/outrigger-client
@@ -41,7 +41,7 @@ function usage() {
     console.log('                                              Used by "subscribe", "run"');
     console.log('       --topic <rendezvous-topic>:            Rendezvous topic');
     console.log('                                              Used by "push", "watch".');
-    console.log('       --outriggerd <hostname:port>:    Hostname/port of outrigger juttle server');
+    console.log('       --outriggerd <hostname:port>:          Hostname/port of outrigger juttle server');
     console.log('       --help:                                Print this help and exit');
     process.exit(1);
 }


### PR DESCRIPTION
Tidy up the spacing in outrigger-client --help. Update README.md to
refer to a single outrigger daemon and not separate juttled/app
servers.

@mnibecker @davidvgalbraith 