### PR TITLE
JuttleBundler: Use JuttleError in instanceof check

### DIFF
--- a/lib/bundler.js
+++ b/lib/bundler.js
@@ -79,9 +79,7 @@ var JuttleBundler = Base.extend({
                     throw JuttledErrors.fileNotFoundError(respath);
                 } else if (err.code === 'EACCES') {
                     throw JuttledErrors.fileAccessError(respath);
-                } else if (err instanceof JuttleErrors.SyntaxError ||
-                           err instanceof JuttleErrors.CompileError ||
-                           err instanceof JuttleErrors.RuntimeError) {
+                } else if (err instanceof JuttleErrors.JuttleError) {
                     // In this case, we return the program and modules along
                     // with the error so the client can display the error in
                     // context.


### PR DESCRIPTION
`JuttleError` wraps all Juttle errors and it is a parent class of `SyntaxError`/`CompileError`/`RuntimeError`, so there is no need to test for them separately.