### PR TITLE
Allow all origins for cors

### DIFF
--- a/lib/service-juttled.js
+++ b/lib/service-juttled.js
@@ -34,11 +34,10 @@ var JuttledService = Base.extend({
             this._max_saved_messages = config.juttled.max_saved_messages;
         }
 
-        // add cors headers
+        // add cors headers, allow ALL origins
         this._app.use(function (req, res, next) {
 
-            // port is set to whatever juttle-vizd is listening to, this should be dynamic
-            res.setHeader('Access-Control-Allow-Origin', 'http://localhost:2000');
+            res.setHeader('Access-Control-Allow-Origin', '*');
             res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS, PUT, PATCH, DELETE');
             res.setHeader('Access-Control-Allow-Headers', 'X-Requested-With,content-type');
 


### PR DESCRIPTION
Could only connect to outriggerd using `localhost:2000`, a relic of our pre-release days. I figure for now outrigger should accept requests from all origins.

@mstemm