### PR TITLE
Docker monitoring demo with cadvisor and influx

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -112,7 +112,7 @@ below this directory. For example, to extend the base configuration to
 add an elasticsearch backend, run:
 
 ```
-docker-compose -f dc-outrigger.yml elastic-newstracker/dc-elastic.yml up
+docker-compose -f dc-outrigger.yml -f elastic-newstracker/dc-elastic.yml -f cadvisor-influx/dc-cadvisor-influx.yml up
 ```
 
 Not every adapter requires additional containers (for example,

--- a/examples/cadvisor-influx/README.md
+++ b/examples/cadvisor-influx/README.md
@@ -1,0 +1,44 @@
+# cAdvisor / InfluxDB Example: Monitoring Docker Containers
+
+# Setup
+
+This example demonstrates using Juttle with an InfluxDB backend via the [influx adapter](https://github.com/juttle/juttle-influx-adapter). We will run docker containers, collect cpu, memory and network activity metrics using the [cAdvisor](https://github.com/google/cadvisor) monitoring daemon, and point cAdvisor at InfluxDB for stats storage.
+
+Our Juttle program will then read the stats from InfluxDB backend and render visualizations of the container activity in the outrigger environment. Since this demo will have 3 docker containers running (influxdb, cadvisor and outrigger), we will monitor statistics from these three, as well as any other containers that happen to be running on the system.
+
+## tl;dr
+
+Run this from the parent `examples` dir (details in the parent [README.md](../README.md)):
+
+```
+docker-compose -f dc-outrigger.yml -f cadvisor-influx/dc-cadvisor-influx.yml up
+```
+
+Then visit this link to see the Juttle dashboard in your browser:
+
+``http://(localhost|docker machine ip):8080/run?path=/examples/cadvisor-influx/cadvisor-dashboard.juttle``
+
+## Additional docker-compose configuration
+
+[dc-cadvisor-influx.yml](./dc-cadvisor-influx.yml) in the current directory adds the following containers:
+
+- influxdb, to store the time series data
+- cadvisor, to extract performance data from docker and populate in influxdb
+
+## ``juttle-config.json`` configuration
+
+``juttle-config.json`` in the parent directory already contains the necessary configuration for the juttle-influx-adapter to communicate with influxdb. It does not require any modification.
+
+# Juttle
+
+We will use Juttle to visualize cpu, memory and network activity of the running docker containers. The Juttle program will read recent metrics from InfluxDB storage.
+
+To run the program, visit ``http://(localhost|docker machine ip):8080/run?path=/examples/cadvisor-influx/cadvisor-dashboard.juttle``
+
+The browser window will render this program's output: a table listing of the monitored docker containers, timecharts of their CPU utilization and network activity, and a barchart of memory usage.
+
+The [Juttle code](cadvisor-dashboard.juttle) uses subgraphs to make the code modular for readability and reuse. Since cAdvisor is reporting cumulative statistics, and we wish to graph point-in-time measurements, the values are put through `sub delta_stat()` which calculates deltas using the logic `value_at_time_1 = cumulative_1 - cumulative_0`. These values are then passed to the visualization sink for rendering.
+
+The current version of the demo shows recent historical data; re-run the program to get a more up-to-date view. Note that cAdvisor buffers data for 1 minute, see issue [#1074](https://github.com/google/cadvisor/issues/1074), so that will be the reporting delay of our dashboard.
+
+A live version of the dashboard is coming soon.

--- a/examples/cadvisor-influx/cadvisor-dashboard.juttle
+++ b/examples/cadvisor-influx/cadvisor-dashboard.juttle
@@ -1,0 +1,69 @@
+/*
+ * This program reads cpu/memory/network statistics for
+ * docker containers, as recorded in InfluxDB by cAdvisor,
+ * and visualizes them. Re-run to get an updated view.
+ */
+
+const duration = :10m:;
+const start = :now: - duration;
+const interval = :5s:; // works well with cadvisor stat frequency
+const cpu_ticks_per_second = 10000000;
+
+// reads exclude occasionally appearing ephemeral container with name '/'
+//
+sub read_stat(stat, from) {
+  read influx -from from -db 'cadvisor' -measurements stat
+    NOT container_name ~ /\/.*/  // exclude ephemeral containers
+}
+
+// cAdvisor metrics are incrementing total counters,
+// and we want a gauge = (value_N - value_N-1) / interval
+//
+sub delta_stat(group) {
+  reduce -forget false -every interval value=last(value) by group
+  | put value = delta(value) by group
+    // can get negative delta after container restart, zero them out
+  | put value = (value > 0) ? value : 0 by group
+  | put value = value / Duration.seconds(interval) by group
+}
+
+sub cpu() {
+  read_stat -stat 'cpu_usage_total' -from start
+  | delta_stat -group 'container_name'
+  | put value = value / cpu_ticks_per_second
+  | view timechart -title 'CPU Usage' -display.dataDensity 0;
+}
+
+sub memory() {
+  read_stat -stat 'memory_usage' -from start
+  | keep container_name, time, value
+  | view barchart -title 'Memory Usage';
+}
+
+sub network() {
+  read_stat -stat 'tx_bytes' -from start
+  | delta_stat -group 'container_name'
+  | view timechart -title 'Network TX' -display.dataDensity 0;
+
+  read_stat -stat 'rx_bytes' -from start
+  | delta_stat -group 'container_name'
+  | view timechart -title 'Network RX' -display.dataDensity 0;
+}
+
+sub containers() {
+  read influx -from start -db 'cadvisor' -measurements 'cpu_usage_total'
+  | reduce by container_name
+  | filter NOT container_name ~ /\/.*/  // exclude ephemeral containers
+  |(
+    reduce value = count()
+    | view tile -title 'Container Count' -col 0 -row 0;
+
+    sort container_name
+    | view table -title 'Running Containers' -col 1 -row 0
+  )
+}
+
+containers;
+cpu;
+memory;
+network;

--- a/examples/cadvisor-influx/dc-cadvisor-influx.yml
+++ b/examples/cadvisor-influx/dc-cadvisor-influx.yml
@@ -1,0 +1,28 @@
+influxdb:
+  container_name: examples_influxdb_1
+  image: tutum/influxdb:latest
+  ports:
+    - "8083:8083"
+    - "8086:8086"
+  expose:
+    - "8090"
+    - "8099"
+  environment:
+    - PRE_CREATE_DB=cadvisor
+cadvisor:
+  image: google/cadvisor-canary:latest
+  command: -storage_driver=influxdb -storage_driver_db=cadvisor -storage_driver_host=influxdb:8086 -logtostderr=true -v=9 -stderrthreshold=9 -storage_driver_buffer_duration=1m
+  ports:
+    - "8081:8080"
+  volumes:
+    - /:/rootfs:ro
+    - /var/run:/var/run:rw
+    - /sys:/sys:ro
+    - /var/lib/docker/:/var/lib/docker:ro
+  links:
+    - influxdb
+outrigger:
+  links:
+    - influxdb
+  external_links:
+    - examples_influxdb_1

--- a/examples/cadvisor-influx/test.juttle
+++ b/examples/cadvisor-influx/test.juttle
@@ -1,0 +1,1 @@
+read influx -from :1m ago: -to :now: -last :1m: -db 'cadvisor' -measurements 'cpu_usage_per_cpu'

--- a/examples/elastic-newstracker/dc-elastic.yml
+++ b/examples/elastic-newstracker/dc-elastic.yml
@@ -2,6 +2,7 @@ elastic_news_data:
    image: juttle/elastic_news_data
 
 elasticsearch:
+  container_name: examples_elasticsearch_1
   image: elasticsearch:2.1.1
   volumes_from:
     - elastic_news_data
@@ -11,4 +12,6 @@ elasticsearch:
 outrigger:
   links:
     - elasticsearch
+  external_links:
+    - examples_elasticsearch_1
 

--- a/examples/index.juttle
+++ b/examples/index.juttle
@@ -7,7 +7,8 @@ emit
     add_subdir_juttle -subdir "core-juttle" -juttle "index" -description "Examples of core juttle features";
     add_subdir_juttle -subdir "twitter-race" -juttle "twitter" -description "Examples using twitter adapter";
     add_subdir_juttle -subdir "elastic-newstracker" -juttle "index" -description "Examples using elasticsearch adapter";
-    add_subdir_juttle -subdir "gmail" -juttle "index" -description "Examples using gmail adapter"
+    add_subdir_juttle -subdir "gmail" -juttle "index" -description "Examples using gmail adapter";
+    add_subdir_juttle -subdir "cadvisor-influx" -juttle "cadvisor-dashboard" -description "Monitor docker containers using cAdvisor and InfluxDB"
 )
 | keep program, description
 | view table -title 'Example Juttle Programs' -markdownFields [ 'program' ]

--- a/examples/juttle-config.json
+++ b/examples/juttle-config.json
@@ -3,9 +3,14 @@
         "elastic": [
             {
                 "id": "local",
-                "address": "elasticsearch",
+                "address": "examples_elasticsearch_1",
                 "port": 9200
             }
-        ]
+        ],
+        "influx": {
+            "url": "http://examples_influxdb_1:8086",
+            "user": "root",
+            "password": "root"
+        }
     }
 }

--- a/examples/twitter-race/README.md
+++ b/examples/twitter-race/README.md
@@ -10,12 +10,12 @@ None needed.
 
 ## ``juttle-config.json`` configuration
 
-Modify `juttle-config.json` to add a ``juttle-twitter-adapter`` section containing credentials to access twitter via API:
+Modify `juttle-config.json` to add a ``twitter`` section containing credentials to access twitter via API:
 
 ```
 {
     "adapters": {
-        "juttle-twitter-adapter": {
+        "twitter": {
             "consumer_key": "...",
             "consumer_secret": "...",
             "access_token_key": "...",


### PR DESCRIPTION
connects to #24 

Our ability to run this demo is blocked on 2 things:

- [InfluxDB v0.9 support · Issue #743 · google_cadvisor](https://github.com/google/cadvisor/issues/743) - should be unblocked, it's merged, although not yet in the official release (use canary image)
- proper support for periodic reads to the backend in "live" mode, which was hacked up with '-lag' option in the pre-open version of this demo. The real influx adapter doesn't support '-lag' so the juttle here cannot run.

Don't merge these demo docs until the above are resolved, or else switch the demo to use a different backend (say Redis instead of Influx) or use something else (REST API?) instead of cadvisor to get the docker container stats.

@demmer @mstemm as we discussed... I will leave what's done here, and file an issue to pick up this work: https://github.com/juttle/outrigger/issues/24