### PR TITLE
client-socket-manager: parse _jut_time_bounds from and to to dates

### DIFF
--- a/src/client-lib/middleware/job-socket.js
+++ b/src/client-lib/middleware/job-socket.js
@@ -24,6 +24,20 @@ const jobMiddleware = store => {
             });
         }
 
+        if (msg.hasOwnProperty('sinks')) {
+            msg.sinks.forEach((sink) => {
+                sink.options._jut_time_bounds.forEach((timeBound) => {
+                    if (timeBound.from) {
+                        timeBound.from = new Date(timeBound.from);
+                    }
+
+                    if (timeBound.to) {
+                        timeBound.to = new Date(timeBound.to);
+                    }
+                });
+            });
+        }
+
         dispatch(Actions.jobMessage(job_id, msg))
     }
 


### PR DESCRIPTION
- Also move date parsing code in job-socket middleware into the client-socket-manager.

The juttle-viz views expect these values to be JavaScript Dates and not JSON serialized string representations of Dates which is what we get over the websocket.

@mnibecker, as we discussed, this code will be removed shortly anyways, since its being extracted out into [juttle-client-library](https://github.com/juttle/juttle-client-library). This "patch" should be applied there.