### PR TITLE
update to juttle v0.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,15 +8,12 @@ addons:
         - g++-4.8
 
 before_install:
-  - export CXX="g++-4.8"
+    - export CXX="g++-4.8"
+    - npm install juttle@0.2.x
 
 node_js:
     - '4.2'
     - '5.0'
-
-
-before_script:
-    - npm install juttle
 
 script:
     - gulp

--- a/lib/juttle-subprocess.js
+++ b/lib/juttle-subprocess.js
@@ -77,7 +77,7 @@ process.on('message', function(msg) {
         compiler.compile(msg.bundle.program, compile_options)
         .then(function(program) {
             // Maps from channel to sink id
-            var sink_descs = _.map(program.get_client_sinks(program), function(sink) {
+            var sink_descs = _.map(program.get_views(program), function(sink) {
                 return {
                     type: sink.name,
                     sink_id: sink.channel,
@@ -100,7 +100,7 @@ process.on('message', function(msg) {
                 logger.warn(msg, warn);
             });
 
-            program.events.on('sink:mark', function(data) {
+            program.events.on('view:mark', function(data) {
                 process.send({
                     type: "data", data: {
                         type: "mark",
@@ -110,7 +110,7 @@ process.on('message', function(msg) {
                 });
             });
 
-            program.events.on('sink:tick', function(data) {
+            program.events.on('view:tick', function(data) {
                 process.send({
                     type: "data", data: {
                         type: "tick",
@@ -120,7 +120,7 @@ process.on('message', function(msg) {
                 });
             });
 
-            program.events.on('sink:eof', function(data) {
+            program.events.on('view:eof', function(data) {
                 process.send({
                     type: "data", data: {
                         type: "sink_end",
@@ -129,7 +129,7 @@ process.on('message', function(msg) {
                 });
             });
 
-            program.events.on('sink:points', function(data) {
+            program.events.on('view:points', function(data) {
                 process.send({
                     type: "data", data: {
                         type: "points",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "webpack-dev-middleware": "^1.2.0"
   },
   "peerDependencies": {
-    "juttle": "0.1.x"
+    "juttle": "0.2.x"
   },
   "engines": {
     "node": ">=4.2.0",


### PR DESCRIPTION
- Bump the juttle peerDependency to 0.2.x.
- Update juttle-subprocess to the modified program API in juttle 0.2.x.

Note that this does not do the full rename of "sink" to "view" (#27).
