### PR TITLE
Add newly required semicolon to es6 class property

### DIFF
--- a/src/client-lib/containers/input-group.js
+++ b/src/client-lib/containers/input-group.js
@@ -8,7 +8,7 @@ class InputGroup extends Component {
         if (e.keyCode === 13 && e.shiftKey) {
             this.props.onRun();
         }
-    }
+    };
 
     render() {
         const { inputs } = this.props;


### PR DESCRIPTION
Simple enough fix, lets hope this passes tests.