### PR TITLE
api.js: remove hard coded localhost and port

### DIFF
--- a/src/client-lib/utils/api.js
+++ b/src/client-lib/utils/api.js
@@ -1,10 +1,9 @@
 import fetch from 'isomorphic-fetch';
 
-const BASE_URL = "http://localhost:8080";
 const API_PREFIX = "/api/v0";
 
 export let getInputs = (bundle, inputs) => {
-    return fetch(`${BASE_URL}${API_PREFIX}/prepare`, {
+    return fetch(`${API_PREFIX}/prepare`, {
         method: "post",
         headers: {
             'Content-Type': 'application/json'
@@ -18,7 +17,7 @@ export let getInputs = (bundle, inputs) => {
 };
 
 export let runJob = (bundle, inputs) => {
-    return fetch(`${BASE_URL}${API_PREFIX}/jobs`, {
+    return fetch(`${API_PREFIX}/jobs`, {
         method: 'post',
         headers: {
             'Accept': 'application/json',
@@ -33,11 +32,11 @@ export let runJob = (bundle, inputs) => {
 };
 
 export let getJob = (jobId) => {
-    return fetch(`${BASE_URL}${API_PREFIX}/jobs/${jobId}`)
+    return fetch(`${API_PREFIX}/jobs/${jobId}`)
     .then(res => res.json());
 };
 
 export let getBundle = (path) => {
-    return fetch(`${BASE_URL}${API_PREFIX}/paths${path}`)
+    return fetch(`${API_PREFIX}/paths${path}`)
     .then(res => res.json());
 };


### PR DESCRIPTION
So that the API calls his the same host/port that the app was fetched from.

@mnibecker 

cc @dmehra this is to make outrigger work in docker correctly.