### PR TITLE
Adding demo of basic juttle programs incl http adapter

### DIFF
--- a/demos/core-juttle/README.md
+++ b/demos/core-juttle/README.md
@@ -1,0 +1,104 @@
+# Core Juttle Demo
+
+## Setup
+
+This demo uses only built-in Juttle processors and adapters.
+All you need to run this demo is to install outrigger and run outriggerd,
+either by using our docker container, or directly:
+
+```
+npm install -g outrigger
+outriggerd &
+```
+
+Then you can run provided Juttle programs with command:
+
+```
+outrigger-client run --path FILEPATH.juttle
+```
+
+The output will be sent to your browser at the URL of this format:
+
+```
+http://localhost:8080/run?path=FILEPATH.juttle
+```
+
+## Juttles
+
+### Hello World!
+
+This basic Juttle program uses the artificial data source `emit` to produce a single
+data point with current timestamp and message field with value 'hello world'.
+
+[hello_world.juttle](hello_world.juttle)
+
+```
+outrigger-client run --path hello_world.juttle
+```
+
+### Sine Wave
+
+Juttle programs can be parameterized with user inputs, such as this math program
+that renders a sine wave function on a timechart with the amplitude and period
+set by the user in the input control boxes.
+
+[sine_wave.juttle](sine_wave.juttle)
+
+```
+outrigger-client run --path sine_wave.juttle
+```
+
+For another example of a program with input, see [fizzbuzz.juttle](fizzbuzz.juttle).
+
+```
+outrigger-client run --path fizzbuzz.juttle
+```
+
+### Stock Prices
+
+Juttle can read data from various supported backends via adapters. A few adapters
+come standard with the language, including reading from a file, and from http endpoint.
+More adapters can be loaded (for example, see [memes-elastic demo](../memes-elastic/README.md)).
+
+This program uses the http adapter to read raw stock price and divident data from
+Yahoo! Finance (for a stock named by the user via a text input box), 
+renders a timechart of daily closing prices over a background of daily trading volume,
+and shows dividend payouts (if any) as events overlaid on the same chart.
+
+[stock_prices.juttle](stock_prices.juttle)
+
+```
+outrigger-client run --path stock_prices.juttle
+```
+
+### Kitchen Duty
+
+Juttle can write points out to the supported backends via adapters.
+
+This fun and useful little program helps us keep the office kitchen clean by
+randomly selecting two team members every day to serve on kitchen duty.
+The program sends a notification to our #food slack channel to alert the chosen ones
+(the http sink is commented out, edit with proper target to see it in action).
+
+Unlike other programs in this set of examples, kitchen_duty.juttle is not meant
+to produce visual output, so we run it via the juttle CLI and not outrigger-client
+(in fact, for the team's daily needs we run it as a cron job on AWS micro instance).
+
+[kitchen_duty.juttle](kitchen_duty.juttle)
+
+```
+juttle kitchen_duty.juttle
+```
+
+### Chart Gallery
+
+Juttle works with juttle-viz library to produce visualizations, including the
+table and timechart used in previous examples, and [more](http://juttle.github.io/juttle-viz/).
+
+This program showcases different charts (XXX/need to finish! Only tile shown right now).
+
+[chart_gallery.juttle](chart_gallery.juttle)
+
+```
+outrigger-client run --path chart_gallery.juttle
+```

--- a/demos/core-juttle/chart_gallery.juttle
+++ b/demos/core-juttle/chart_gallery.juttle
@@ -1,0 +1,10 @@
+// Showcase juttle-viz charts
+//
+// XXX add more charts, only tile for now
+
+(
+emit -limit 10 | put value=count() | put name='apples';
+emit -limit 10 | put value=count() | put name='bananas'
+)
+| view tile -facetFields ['name']
+

--- a/demos/core-juttle/fizzbuzz.juttle
+++ b/demos/core-juttle/fizzbuzz.juttle
@@ -1,0 +1,26 @@
+//
+// Juttle version of the fizzbuzz programmer test
+//
+// The number of runs is configurable with an input control, e.g:
+//
+// $ juttle fizzbuzz.juttle --input N=30
+//
+
+input N: number -default 100;
+
+function fizzbuzz(x) {
+    if (x % 3 == 0 && x % 5 == 0) {
+        return "fizzbuzz";
+    } else if (x % 3 == 0) {
+        return "fizz";
+    } else if (x % 5 == 0) {
+        return "buzz";
+    } else {
+        return x;
+    }
+}
+
+emit -from :0: -limit N
+  | put i = count() - 1, x = fizzbuzz(i)
+  | keep i, x
+  | view table

--- a/demos/core-juttle/hello_world.juttle
+++ b/demos/core-juttle/hello_world.juttle
@@ -1,0 +1,4 @@
+//
+// Hello world in juttle
+//
+emit -limit 1 | put message = 'hello world' | view table

--- a/demos/core-juttle/kitchen_duty.juttle
+++ b/demos/core-juttle/kitchen_duty.juttle
@@ -1,0 +1,64 @@
+/* This Juttle program helps us keep the office kitchen clean!
+ * 
+ * It randomly picks two people to serve kitchen duty every day
+ * and sends a notification to our slack channel #food.
+ * We run it as a cron job on an AWS micro instance.
+ */
+
+// Emit the list of potential candidates for kitchen duty
+sub people() {
+  const names = [
+    { "name":"mccanne" },
+    { "name":"stemm" },
+    { "name":"matt" },
+    { "name":"vlad" },
+    { "name":"oleg" },
+    { "name":"dave" },
+    { "name":"demmer" },
+    { "name":"dmehra" },
+    { "name":"rodney" }
+  ];
+
+  emit -points names -from :0:
+  | remove time
+}
+
+// Choose n points at random
+sub pick(n) {
+  put rank = Math.random()
+  | sort rank
+  | head n
+  | remove rank
+}
+
+// Combine the value of the given field from all points in the batch into a
+// single array.
+reducer combine(field) {
+  var names = [];
+  function update() {
+    names[Array.length(names)] = *field;
+  }
+  function result() {
+    return names;
+  }
+}
+
+// Send the incoming points to slack
+sub slack() {
+  // SET CORRECT URL HERE
+  const url = 'https://hooks.slack.com/services/ABC/DEF/GHI';
+
+  put channel="#test-alerts", username="Kitchen Duty", icon_emoji = ":fork_and_knife:"
+  | write http -url url -maxLength 1
+}
+
+// Put it all together
+people
+| pick -n 2
+| reduce names=combine(name)
+| put text = "Today's kitchen duty: ${names[0]} and ${names[1]}"
+| remove names
+|(
+  view table; 
+//  slack    // UNCOMMENT ME
+)

--- a/demos/core-juttle/sine_wave.juttle
+++ b/demos/core-juttle/sine_wave.juttle
@@ -1,0 +1,11 @@
+input period: number -default 50 -label 'Sine Wave period';
+input amplitude: number -default 10 -label 'Sine Wave amplitude';
+
+emit -from :-5m: -limit 10000
+| put value =  amplitude * Math.sin(Math.PI * count() / period)
+| view timechart -title "Sine Wave";
+
+emit -from :-5m: -limit 10000
+| put value=count()
+| put value = value * value
+| view timechart -title "Geometric Growth";

--- a/demos/core-juttle/stock_prices.juttle
+++ b/demos/core-juttle/stock_prices.juttle
@@ -1,0 +1,65 @@
+/*
+ * Reading stock quote data from Yahoo Finance via built-in http adapter
+ *
+ * $ juttle stock_prices.juttle --input symbol=goog
+ */
+
+input symbol: text -default 'IBM' -label 'Stock Ticker';
+
+const start = :1 year ago:;
+const end   = :now:;
+
+// Calculate the time span parameters
+const a = Date.get(start, 'month') - 1;
+const b = Date.get(start, 'day') - 1;
+const c = Date.get(start, 'year');
+const d = Date.get(end, 'month') - 1;
+const e = Date.get(end, 'day') - 1;
+const f = Date.get(end, 'year');
+
+// Fetch either data (d) or dividends (v)
+sub fetch(what) {
+  const url = 'http://real-chart.finance.yahoo.com/table.csv?s=${symbol}&a=${a}&b=${b}&c=${c}&d=${d}&e=${d}&f=${f}&g=${what}&ignore=.csv';
+  read http -url url
+  | put #Symbol = symbol
+  | put date = Date.new(#Date)
+  | sort date
+  | put time = date
+}
+
+function sanitizeValue(value) {
+  if (value == null) {
+    return 0;
+  } else {
+    return Number.fromString(value);
+  }
+}
+
+sub prices() {
+  fetch -what 'd'
+  | keep time, Close, Volume
+  | split
+  | reduce -forget false -every :d: value=last(value) by name
+  | put value = sanitizeValue(value)
+  | view timechart 
+      -title '${symbol} closing price' -id 'chart'
+      -display.dataDensity 0
+      -keyField 'name'
+      -valueField 'value'
+      -series [
+        {name: 'Close', geom: 'line', yScale: 'primary'}, 
+        {name: 'Volume', geom: 'bars', yScale: 'secondary'} 
+    ];
+}
+
+sub dividends() {
+  fetch -what 'v'
+  | put message = "Dividend of $${Dividends} per share"
+  |(
+    view table -title "Dividends paid";
+    view events -on 'chart' -messageField 'message'
+  )
+}
+
+prices;
+dividends;


### PR DESCRIPTION
@demmer @mccanne these are the demos that used to be [private here](https://github.com/juttle/outrigger-pre-open/tree/demo-2015-12-09) including the stock prices, kitchen duty, and math. They work on outrigger 0.2.0. 

We can add instructions for using in the docker container tomorrow.