### PR TITLE
app-router: don't depend on the cwd to look for the dist dir

### DIFF
--- a/lib/app-router.js
+++ b/lib/app-router.js
@@ -1,15 +1,16 @@
 var fs = require('fs');
 var path = require('path');
 var express = require('express');
+var logger = require('log4js').getLogger('app-router');
 
-var DIST_DIR = 'dist';
+var DIST_DIR = path.join(__dirname, '..', 'dist');
 
 module.exports.init = function() {
     var router = express.Router();
     var devMode;
 
     try {
-        var distDir = fs.statSync(path.resolve(DIST_DIR));
+        var distDir = fs.statSync(DIST_DIR);
         devMode = !distDir.isDirectory();
     }
     catch(err) {
@@ -17,6 +18,7 @@ module.exports.init = function() {
     }
 
     if (devMode) {
+        logger.info('dist dir not found -- running in development mode');
         var webpack = require('webpack');
         var webpackDevMiddleware = require('webpack-dev-middleware');
         var webpackConfig = require('../webpack.config');
@@ -29,7 +31,7 @@ module.exports.init = function() {
         }));
     } else {
         // serve static assets from dist
-        router.use('/assets', express.static(path.join(__dirname, '..', 'dist')));
+        router.use('/assets', express.static(DIST_DIR));
     }
 
     router.get('/run', function(req, res) {


### PR DESCRIPTION
Now the router always searches for the `dist` dir in a location
relative to the file lib/app-router.js instead of partially by
the cwd and partially by the __dirname of the file.