### PR TITLE
demos: update sine_wave example to have an alert threshold

### DIFF
--- a/demos/core-juttle/sine_wave.juttle
+++ b/demos/core-juttle/sine_wave.juttle
@@ -1,11 +1,14 @@
-input period: number -default 50 -label 'Sine Wave period';
+input period: number -default 5 -label 'Sine Wave period (seconds)';
 input amplitude: number -default 10 -label 'Sine Wave amplitude';
+input threshold: number -default 9 -label 'Alert threshold';
 
-emit -from :-5m: -limit 10000
-| put value =  amplitude * Math.sin(Math.PI * count() / period)
-| view timechart -title "Sine Wave";
+emit -from :-30s: -every :.1 seconds: -limit 10000
+| put value =  amplitude * Math.sin(Math.PI * count() / 10 / (period / 2))
+| (
+    view timechart -title "Sine Wave" -id "chart";
 
-emit -from :-5m: -limit 10000
-| put value=count()
-| put value = value * value
-| view timechart -title "Geometric Growth";
+    reduce -every :.5s: -over :.5s: value=avg(value)
+    | filter value > threshold
+    | put message="average value ${Math.floor(value * 1000) / 1000} > threshold ${threshold}"
+    | view events -on 'chart'
+  )


### PR DESCRIPTION
FYI @dmehra here's the sine_wave example with overlaid event threshold alerting based on a windowed moving average.
