### PR TITLE
Pass config path to juttle subprocess.

### DIFF
--- a/lib/job-handlers.js
+++ b/lib/job-handlers.js
@@ -9,7 +9,8 @@ var job_mgr;
 var observer_mgr;
 
 function init(options) {
-    job_mgr = new JobManager({max_saved_messages: options.max_saved_messages});
+    job_mgr = new JobManager({max_saved_messages: options.max_saved_messages,
+                              config_path: options.config_path});
     observer_mgr = new ObserverManager({job_mgr: job_mgr});
 }
 

--- a/lib/job-manager.js
+++ b/lib/job-manager.js
@@ -21,6 +21,7 @@ var JuttleJob = Base.extend({
 
         self._bundle = options.bundle;
         self._inputs = options.inputs;
+        self._config_path = options.config_path;
 
         // An array of WebsocketEndpoint objects.
         self._endpoints = options.endpoints;
@@ -78,8 +79,15 @@ var JuttleJob = Base.extend({
 
         logger.debug(self._log_prefix + "Starting job");
 
-        // We run the juttle program in a subprocess.
-        self._child = child_process.fork(__dirname + "/juttle-subprocess.js", {silent: true});
+        // We run the juttle program in a subprocess. Note that the
+        // only argument to the subprocess is the value of the
+        // --config file (if defined).
+        var args = [];
+        if (self._config_path) {
+            args.push(self._config_path);
+        }
+
+        self._child = child_process.fork(__dirname + "/juttle-subprocess.js", args, {silent: true});
 
         self._child.on('message', function(msg) {
             //logger.debug("Got message from child", msg);
@@ -253,6 +261,8 @@ var JobManager = Base.extend({
     initialize: function(options) {
         var self = this;
 
+        self._config_path = options.config_path;
+
         // job_id -> JuttleJob
         self._jobs = {};
 
@@ -316,7 +326,8 @@ var JobManager = Base.extend({
             bundle: options.bundle,
             inputs: options.inputs,
             endpoints: [],
-            max_saved_messages: self._max_saved_messages
+            max_saved_messages: self._max_saved_messages,
+            config_path: self._config_path
         });
 
         self._jobs[job_id] = job;

--- a/lib/juttle-subprocess.js
+++ b/lib/juttle-subprocess.js
@@ -40,7 +40,11 @@ var logger = JuttleLogger.getLogger('juttle-subprocess');
 
 var read_config = require('juttle/lib/config/read-config');
 var Juttle = require('juttle/lib/runtime').Juttle;
-var config = read_config();
+
+// The only argument to this process is the path to the config
+// file. May not be provided, in which case a default set of search
+// paths will be used.
+var config = read_config({config_path: process.argv[2]});
 var compiler = require('juttle/lib/compiler');
 var optimize = require('juttle/lib/compiler/optimize');
 var views_sourceinfo = require('juttle/lib/compiler/flowgraph/views_sourceinfo');

--- a/lib/service-juttled.js
+++ b/lib/service-juttled.js
@@ -22,6 +22,7 @@ var JuttledService = Base.extend({
         Juttle.adapters.load(config.adapters);
         var self = this;
 
+        self._config_path = options.config_path;
         this._app = express();
         expressWs(this._app);
 
@@ -56,7 +57,8 @@ var JuttledService = Base.extend({
 
     initRoutes: function() {
 
-        jobs.init({max_saved_messages: this._max_saved_messages});
+        jobs.init({max_saved_messages: this._max_saved_messages,
+                   config_path: this._config_path});
         paths.init({root_directory: this._root_directory});
 
         this._app.get(API_PREFIX + '/jobs',


### PR DESCRIPTION
Plumb the --config argument down to the JuttleJob as an option
config_file. It is passed to the spawned subprocess as the only
process argument.

The subprocess in turn calls read_config with argv[2]. If undefined,
it falls back to the default set of search paths.

This fixes #62.

@demmer 