### PR TITLE
Allow late-joining websockets to get program output.

### DIFF
--- a/lib/job-handlers.js
+++ b/lib/job-handlers.js
@@ -10,7 +10,7 @@ var observer_mgr;
 
 function init(options) {
     job_mgr = new JobManager({max_saved_messages: options.max_saved_messages,
-                              lingering_job_timeout: options.lingering_job_timeout,
+                              delayed_job_cleanup: options.delayed_job_cleanup,
                               config_path: options.config_path});
     observer_mgr = new ObserverManager({job_mgr: job_mgr});
 }

--- a/lib/job-handlers.js
+++ b/lib/job-handlers.js
@@ -10,6 +10,7 @@ var observer_mgr;
 
 function init(options) {
     job_mgr = new JobManager({max_saved_messages: options.max_saved_messages,
+                              lingering_job_timeout: options.lingering_job_timeout,
                               config_path: options.config_path});
     observer_mgr = new ObserverManager({job_mgr: job_mgr});
 }

--- a/lib/job-manager.js
+++ b/lib/job-manager.js
@@ -286,7 +286,7 @@ var JobManager = Base.extend({
         self._jobs = {};
 
         self._max_saved_messages = options.max_saved_messages;
-        self._lingering_job_timeout = options.lingering_job_timeout;
+        self._delayed_job_cleanup = options.delayed_job_cleanup;
 
         // This object emits job_start/job_end events when jobs are
         // started and deleted.
@@ -321,6 +321,8 @@ var JobManager = Base.extend({
         var self = this;
 
         if (_.has(self._jobs, job_id)) {
+            logger.debug("Removing job " + job_id + " from jobs hash");
+
             self._jobs[job_id].stop();
 
             // Remove the job from the jobs hash now, so list_jobs
@@ -361,10 +363,14 @@ var JobManager = Base.extend({
             // connect and receive the output of very short programs,
             // we actually remove the job from the hash after a short
             // timeout.
-            setTimeout(function() {
-                logger.debug("Removing from jobs hash");
-                self._jobs = _.omit(self._jobs, job_id);
-            }, self._lingering_job_timeout);
+            // If the timeout is 0, we remove the job immediately.
+            if (self._delayed_job_cleanup === 0) {
+                self.delete_job(job_id);
+            } else {
+                setTimeout(function() {
+                    self.delete_job(job_id);
+                }, self._delayed_job_cleanup);
+            }
         });
 
         self.events.trigger("job_start", job_id, options.observer_id);

--- a/lib/job-manager.js
+++ b/lib/job-manager.js
@@ -42,7 +42,16 @@ var JuttleJob = Base.extend({
         self._log_prefix = '(job=' + self._job_id + ') ';
 
         self._received_program_started = false;
+        self._job_stopped = false;
         self._sink_descs = undefined;
+
+        // This is used in multiple places and only depends on the job
+        // id, so create it now.
+        self._job_end_msg = {
+            type: "job_end",
+            job_id: self._job_id
+        };
+
 
         logger.debug(self._log_prefix + "Created job");
     },
@@ -181,8 +190,19 @@ var JuttleJob = Base.extend({
         // sent a program_started message, send this endpoint a job
         // started message.
         if (self._received_program_started) {
+            logger.debug(self._log_prefix + "Received program started, replaying messages");
             self.job_started([endpoint]);
             self.replay(endpoint);
+
+            // If the job has also stopped, this means that the endpoint
+            // is connecting after the program has finished. Just send the
+            // endpoint a job_stop message and close the endpoint.
+            if (self._job_stopped) {
+                logger.debug(self._log_prefix + "Received job stopped, sending this endpoint a job_stopped message and closing");
+                endpoint.send(self._job_end_msg);
+                endpoint.close();
+                return;
+            }
         }
 
         self._endpoints.push(endpoint);
@@ -235,10 +255,9 @@ var JuttleJob = Base.extend({
 
         logger.debug(self._log_prefix + "Job stopped");
 
-        self.send({
-            type: "job_end",
-            job_id: self._job_id
-        });
+        self.send(self._job_end_msg);
+
+        self._job_stopped = true;
 
         self.events.trigger('end');
     },
@@ -267,6 +286,7 @@ var JobManager = Base.extend({
         self._jobs = {};
 
         self._max_saved_messages = options.max_saved_messages;
+        self._lingering_job_timeout = options.lingering_job_timeout;
 
         // This object emits job_start/job_end events when jobs are
         // started and deleted.
@@ -333,9 +353,18 @@ var JobManager = Base.extend({
         self._jobs[job_id] = job;
 
         job.events.on('end', function() {
-            // The job is complete. Remove it from the jobs hash.
+
             self.events.trigger("job_end", job_id, options.observer_id);
-            self._jobs = _.omit(self._jobs, job_id);
+
+            // The job is complete. Remove it from the jobs hash. In
+            // order to give time for very late job subscribers to
+            // connect and receive the output of very short programs,
+            // we actually remove the job from the hash after a short
+            // timeout.
+            setTimeout(function() {
+                logger.debug("Removing from jobs hash");
+                self._jobs = _.omit(self._jobs, job_id);
+            }, self._lingering_job_timeout);
         });
 
         self.events.trigger("job_start", job_id, options.observer_id);

--- a/lib/service-juttled.js
+++ b/lib/service-juttled.js
@@ -30,14 +30,15 @@ var JuttledService = Base.extend({
 
         this._root_directory = options.root_directory;
         this._max_saved_messages = 1024;
-        this._lingering_job_timeout = 10000;
+        this._delayed_job_cleanup = 10000;
+
         if (_.has(config, "juttled")) {
             if (_.has(config.juttled, "max_saved_messages")) {
                 this._max_saved_messages = config.juttled.max_saved_messages;
             }
 
-            if (_.has(config.juttled, "lingering_job_timeout")) {
-                this._lingering_job_timeout = config.juttled.lingering_job_timeout;
+            if (_.has(config.juttled, "delayed_job_cleanup")) {
+                this._delayed_job_cleanup = config.juttled.delayed_job_cleanup;
             }
         }
 
@@ -64,7 +65,7 @@ var JuttledService = Base.extend({
     initRoutes: function() {
 
         jobs.init({max_saved_messages: this._max_saved_messages,
-                   lingering_job_timeout: this._lingering_job_timeout,
+                   delayed_job_cleanup: this._delayed_job_cleanup,
                    config_path: this._config_path});
         paths.init({root_directory: this._root_directory});
 

--- a/lib/service-juttled.js
+++ b/lib/service-juttled.js
@@ -30,9 +30,15 @@ var JuttledService = Base.extend({
 
         this._root_directory = options.root_directory;
         this._max_saved_messages = 1024;
-        if (_.has(config, "juttled") &&
-            _.has(config.juttled, "max_saved_messages")) {
-            this._max_saved_messages = config.juttled.max_saved_messages;
+        this._lingering_job_timeout = 10000;
+        if (_.has(config, "juttled")) {
+            if (_.has(config.juttled, "max_saved_messages")) {
+                this._max_saved_messages = config.juttled.max_saved_messages;
+            }
+
+            if (_.has(config.juttled, "lingering_job_timeout")) {
+                this._lingering_job_timeout = config.juttled.lingering_job_timeout;
+            }
         }
 
         // add cors headers, allow ALL origins
@@ -58,6 +64,7 @@ var JuttledService = Base.extend({
     initRoutes: function() {
 
         jobs.init({max_saved_messages: this._max_saved_messages,
+                   lingering_job_timeout: this._lingering_job_timeout,
                    config_path: this._config_path});
         paths.init({root_directory: this._root_directory});
 

--- a/lib/websocket-endpoint.js
+++ b/lib/websocket-endpoint.js
@@ -79,7 +79,7 @@ var WebsocketEndpoint = Base.extend({
         // If there are any queued messages, wait for them to all be
         // sent first. Just set _closed to true. The end of drain()
         // will call close() again once the queue is empty.
-        if (self._message_queue.length > 0 &&
+        if (! self._message_queue.isEmpty() &&
             force !== true) {
             self._closing = true;
             return;
@@ -148,11 +148,6 @@ var WebsocketEndpoint = Base.extend({
             return;
         }
 
-        if (self._message_queue.isEmpty() &&
-            self._closing) {
-            self.close();
-        }
-
         var data = self._message_queue.dequeue();
 
         self._ws.sendAsync(JSON.stringify(data))
@@ -165,6 +160,8 @@ var WebsocketEndpoint = Base.extend({
                 // If the queue is non-empty, call drain again.
                 if (! self._message_queue.isEmpty()) {
                     self.drain();
+                } else if (self._closing) {
+                    self.close();
                 }
             });
     }

--- a/lib/websocket-endpoint.js
+++ b/lib/websocket-endpoint.js
@@ -31,11 +31,13 @@ var WebsocketEndpoint = Base.extend({
         this._message_queue = new Deque();
 
         this._ws.on('message', this.message.bind(this));
-        this._ws.on('close', this.close.bind(this));
+        this._ws.on('close', this.close.bind(this, true));
         this._ws.on('error', function(err) {
             logger.error('websocket err occurred, closing', err);
-            self.close();
+            self.close(true);
         });
+
+        self._closing = false;
 
         this._ping_interval_id = setInterval(function() {
             self.ping();
@@ -69,8 +71,19 @@ var WebsocketEndpoint = Base.extend({
         self.events.trigger('message', message);
     },
 
-    close: function() {
+    close: function(force) {
         var self = this;
+
+        force = force || false;
+
+        // If there are any queued messages, wait for them to all be
+        // sent first. Just set _closed to true. The end of drain()
+        // will call close() again once the queue is empty.
+        if (self._message_queue.length > 0 &&
+            force !== true) {
+            self._closing = true;
+            return;
+        }
 
         // Stop pinging
         if (self._ping_interval_id) {
@@ -131,9 +144,13 @@ var WebsocketEndpoint = Base.extend({
     drain: function() {
         var self = this;
 
-        if (self._ws.readyState !== WebSocket.OPEN ||
-            self._message_queue.isEmpty()) {
+        if (self._ws.readyState !== WebSocket.OPEN) {
             return;
+        }
+
+        if (self._message_queue.isEmpty() &&
+            self._closing) {
+            self.close();
         }
 
         var data = self._message_queue.dequeue();

--- a/test/juttled/juttled.spec.js
+++ b/test/juttled/juttled.spec.js
@@ -85,8 +85,7 @@ describe("Juttled Tests", function() {
             return start_job_check_job_id();
         });
 
-        it("Start 2 jobs at once, should return both jobs", function(done) {
-            this.timeout(5000);
+        it("Start 2 jobs at once, should return both jobs", function() {
             var job_ids = [];
             var bundle;
             return run_path('forever.juttle')
@@ -116,14 +115,10 @@ describe("Juttled Tests", function() {
                 return chakram.all(_.map(job_ids, function(job_id) {
                     return chakram.delete(jd + "/jobs/" + job_id);
                 }));
-            })
-            .then(function() {
-                done();
             });
         });
 
-        it("Start & stop two jobs. Fetch all job ids, should not return anything", function(done) {
-            this.timeout(5000);
+        it("Start & stop two jobs. Fetch all job ids, should not return anything", function() {
             var job_ids = [];
             return run_path('forever.juttle')
             .then(function(res) {
@@ -155,9 +150,6 @@ describe("Juttled Tests", function() {
                 expect(response).to.have.status(200);
                 expect(response).to.have.json([]);
                 return chakram.wait();
-            })
-            .then(function() {
-                done();
             });
         });
     });
@@ -893,7 +885,6 @@ describe("Juttled Tests", function() {
         };
 
         describe('Valid Cases', function() {
-            this.timeout(30000);
             it('Single websocket can get start, points, end messages', function(done) {
                 run_program_with_initial_timeout(2000, done);
             });

--- a/test/juttled/juttled.spec.js
+++ b/test/juttled/juttled.spec.js
@@ -85,7 +85,8 @@ describe("Juttled Tests", function() {
             return start_job_check_job_id();
         });
 
-        it("Start 2 jobs at once, should return both jobs", function() {
+        it("Start 2 jobs at once, should return both jobs", function(done) {
+            this.timeout(5000);
             var job_ids = [];
             var bundle;
             return run_path('forever.juttle')
@@ -115,10 +116,14 @@ describe("Juttled Tests", function() {
                 return chakram.all(_.map(job_ids, function(job_id) {
                     return chakram.delete(jd + "/jobs/" + job_id);
                 }));
+            })
+            .then(function() {
+                done();
             });
         });
 
-        it("Start & stop two jobs. Fetch all job ids, should not return anything", function() {
+        it("Start & stop two jobs. Fetch all job ids, should not return anything", function(done) {
+            this.timeout(5000);
             var job_ids = [];
             return run_path('forever.juttle')
             .then(function(res) {
@@ -150,6 +155,9 @@ describe("Juttled Tests", function() {
                 expect(response).to.have.status(200);
                 expect(response).to.have.json([]);
                 return chakram.wait();
+            })
+            .then(function() {
+                done();
             });
         });
     });
@@ -890,7 +898,7 @@ describe("Juttled Tests", function() {
                 run_program_with_initial_timeout(2000, done);
             });
 
-            it.only('Late subscriber (after job stops) can still get start, points, end messages', function(done) {
+            it('Late subscriber (after job stops) can still get start, points, end messages', function(done) {
                 run_program_with_initial_timeout(8000, done);
             });
         });


### PR DESCRIPTION
Allow late-joining websockets to get a program's output even after a
job ends by adding a configurable delay before actually removing a job
from the job manager's set of jobs. This can be changed by
juttle-config's juttled.lingering_job_timeout option, and defaults to
10 seconds.

During the lingering timeout, the job is marked as stopped. When
adding an endpoint to a job, do a second check to see if the job is
stopped. If it is, replay all messages, send the job_stop message, and
close the connection.

This revealed a possible race condition where a endpoint.close() could
be called before all messages have actually been sent. To address
this, add a flag endpoint:_closing which is set to true in
endpoint.close() if there are queued messages. In drain() once the
queue is empty it calls endpoint.close() again.

Add a unit test that has a websocket join after the program completes,
but before the lingering timeout kicks in.

This fixes #64.

@mnibecker @go-oleg 