### PR TITLE
travis: don't explicitly install juttle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ addons:
 
 before_install:
     - export CXX="g++-4.8"
-    - npm install juttle@0.2.x
 
 node_js:
     - '4.2'


### PR DESCRIPTION
juttle is now a true dependency instead of a peerDependency so it will get installed by `npm install`

@rlgomes 