### PR TITLE
Fix build

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -68,7 +68,7 @@ function gulp_test() {
     return gulp.src('test/**/*.spec.js')
         .pipe(mocha({
             log: true,
-            timeout: 5000,
+            timeout: 30000,
             reporter: 'spec',
             ui: 'bdd',
             ignoreLeaks: true,

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "react": "^0.14.2",
     "react-dom": "^0.14.2",
     "react-redux": "^4.0.0",
+    "react-select": "^0.9.1",
     "redux": "^3.0.4",
     "redux-logger": "^2.0.4",
     "redux-thunk": "^1.0.0",


### PR DESCRIPTION
The 5-second timeout is sometimes too short for some of the elaborate websocket tests we have. And we have this unmet dependency `react-select` that causes a bunch of errors for webpack and somehow hangs builds. With these changes, the build is green again.

@rlgomes 