### PR TITLE
add 'show juttle' toggle to view juttle source

### DIFF
--- a/src/apps/run/components/juttle-viewer.js
+++ b/src/apps/run/components/juttle-viewer.js
@@ -1,0 +1,35 @@
+import React, { Component } from "react";
+
+class JuttleViewer extends Component {
+    constructor() {
+        super();
+        this.state = {
+            sourceVisible: false
+        };
+    }
+
+    _onToggleVisiblityClick() {
+        this.setState({
+            sourceVisible: !this.state.sourceVisible
+        });
+    }
+
+    render() {
+        let juttleSource = false;
+
+        if (this.state.sourceVisible) {
+            juttleSource = (<pre className="juttle-source">{this.props.juttleSource}</pre>);
+        }
+
+        return (
+            <div>
+                <a className="juttle-source-toggle" onClick={this._onToggleVisiblityClick.bind(this)}>
+                    {this.state.sourceVisible ? "Hide Juttle" : "Show Juttle"}
+                </a>
+                {juttleSource}
+            </div>
+        )
+    }
+}
+
+export default JuttleViewer;

--- a/src/apps/run/index.html
+++ b/src/apps/run/index.html
@@ -9,6 +9,7 @@
         <div class="outrigger">
             <div class="main-view">
                 <span class="logo">OUTRIGGER</span>
+                <div id="juttle-source"></div>
                 <div id="juttle-view-layout"></div>
             </div>
             <div class="right-rail">

--- a/src/apps/run/main.js
+++ b/src/apps/run/main.js
@@ -1,8 +1,13 @@
 import url from 'fast-url-parser';
 
+import ReactDOM from 'react-dom';
+import React from 'react';
+
 import Juttle from 'juttle-client-library';
 import * as api from '../../client-lib/utils/api';
 import RendezvousSocket from '../../client-lib/utils/rendezvous-socket';
+
+import JuttleViewer from './components/juttle-viewer';
 
 import 'juttle-client-library/dist/juttle-client-library.css';
 import '../sass/main.scss';
@@ -12,14 +17,17 @@ let outriggerHost = window.location.host;
 let client = new Juttle(outriggerHost);
 let view = new client.View(document.getElementById("juttle-view-layout"));
 let inputs = new client.Input(document.getElementById("juttle-input-groups"));
+let juttleSourceEl = document.getElementById("juttle-source");
 
 let currentBundle;
 let parsed = url.parse(window.location.href, true);
 
 let initBundle = (bundle) => {
+    ReactDOM.render(<JuttleViewer juttleSource={bundle.program} />, juttleSourceEl);
     currentBundle = bundle;
     client.describe(bundle)
     .then((desc) => {
+
         // if we have no inputs go ahead and run
         if (desc.inputs.length === 0) {
             view.run(bundle);

--- a/src/apps/sass/main.scss
+++ b/src/apps/sass/main.scss
@@ -52,5 +52,4 @@ span.logo {
     color: inherit;
     margin-top: 10px;
     margin-bottom: 10px;
-    max-height: 200px;
 }

--- a/src/apps/sass/main.scss
+++ b/src/apps/sass/main.scss
@@ -38,3 +38,19 @@ span.logo {
     padding: 10px;
     @include flex-shrink(0);
 }
+
+.juttle-source-toggle {
+    cursor: pointer;
+
+    &:hover {
+        text-decoration: none;
+    }
+}
+
+.juttle-source {
+    background-color: transparent;
+    color: inherit;
+    margin-top: 10px;
+    margin-bottom: 10px;
+    max-height: 200px;
+}


### PR DESCRIPTION
Add a basic show/hide juttle toggle link
- starts off hidden
- expands to max-height of 200px and then scrolls

Resolves #59 

![image](https://cloud.githubusercontent.com/assets/3344137/12344131/c3165bc6-baee-11e5-8d69-d523f2fff726.png)

![image](https://cloud.githubusercontent.com/assets/3344137/12344135/ce665bf2-baee-11e5-9fdf-a1d633c38666.png)

let me know if you want any styling changes

@mnibecker @davidvgalbraith 

cc @dmehra 