### PR TITLE
use jsdp to serialize messages from juttle-subprocess to job-manager

### DIFF
--- a/lib/juttle-subprocess.js
+++ b/lib/juttle-subprocess.js
@@ -57,6 +57,10 @@ Juttle.adapters.configure(config.adapters);
 
 var running_program;
 
+function send(msg) {
+    process.send(JSDP.serialize(JSDPValueConverter.convertToJSDPValue(msg), { toObject: true }));
+}
+
 process.on('message', function(msg) {
 
     if (msg.cmd === 'stop') {
@@ -92,7 +96,7 @@ process.on('message', function(msg) {
                 };
             });
 
-            process.send({
+            send({
                 type: "program_started",
                 sinks: sink_descs
             });
@@ -108,7 +112,7 @@ process.on('message', function(msg) {
             });
 
             program.events.on('view:mark', function(data) {
-                process.send({
+                send({
                     type: "data", data: {
                         type: "mark",
                         time: data.time,
@@ -118,7 +122,7 @@ process.on('message', function(msg) {
             });
 
             program.events.on('view:tick', function(data) {
-                process.send({
+                send({
                     type: "data", data: {
                         type: "tick",
                         time: data.time,
@@ -128,7 +132,7 @@ process.on('message', function(msg) {
             });
 
             program.events.on('view:eof', function(data) {
-                process.send({
+                send({
                     type: "data", data: {
                         type: "sink_end",
                         sink_id: data.channel
@@ -137,7 +141,7 @@ process.on('message', function(msg) {
             });
 
             program.events.on('view:points', function(data) {
-                process.send({
+                send({
                     type: "data", data: {
                         type: "points",
                         points: data.points,
@@ -157,19 +161,19 @@ process.on('message', function(msg) {
         .then(function() {
             logger.debug('program done');
             running_program = null;
-            process.send({
+            send({
                 type: "done"
             });
         })
         .catch(function(err) {
-            process.send({
+            send({
                 type: "compile_error",
                 err: err
             });
 
             // Also send a done message so the job manager stops the
             // job
-            process.send({
+            send({
                 type: "done"
             });
         });

--- a/test/juttled/juttled.spec.js
+++ b/test/juttled/juttled.spec.js
@@ -791,13 +791,19 @@ describe("Juttled Tests", function() {
                 chakram.post(jd + '/jobs', {
                     bundle: {program: 'import \"module.juttle\" as mod;' +
                              'input my_input: dropdown -label "My Input" -items [10, 20, 30];' +
-                             'emit -limit 5 | put val=my_input | batch -every :1s: | view table;' +
+                             'input my_date_input: date;' +
+                             'emit -limit 5 | put fromInput = true, val=my_input, datePlus2s = my_date_input + :2s: | batch -every :1s: | view table;' +
                              'emit -limit 5 | put val2=mod.val | batch -every :1s: | view logger',
                              modules: {
                                  'module.juttle': 'export const val=30;'
                              }
                             },
-                    inputs: {my_input: 20}
+                    inputs: JSDP.serialize({
+                        my_input: 20,
+                        my_date_input: new Date(1000)
+                    }, {
+                        toObject: true
+                    })
                 })
                 // Add a 2 second delay to force use of the job
                 // manager replay ability for new websockets.
@@ -812,7 +818,7 @@ describe("Juttled Tests", function() {
                     ws_client = new WebSocket(jd + '/jobs/' + job_id);
                     ws_client.on('message', function(data) {
                         //console.log("Got Websocket:", data);
-                        data = JSON.parse(data);
+                        data = JSDP.deserialize(data);
                         if (data.type === 'job_start') {
                             got_job_start = true;
                             expect(data.job_id === job_id);
@@ -879,8 +885,9 @@ describe("Juttled Tests", function() {
                             // val properties come from the
                             // input. val2 properties come from the
                             // module.
-                            if (_.has(data.points[0], "val")) {
+                            if (_.has(data.points[0], "fromInput")) {
                                 expect(data.points[0].val).to.equal(20);
+                                expect(data.points[0].datePlus2s.getTime()).to.equal(new Date(3000).getTime());
                             } else {
                                 expect(data.points[0].val2).to.equal(30);
                             }
@@ -894,7 +901,7 @@ describe("Juttled Tests", function() {
             it('Websocket connection to non-existent job, should get reasonable message', function(done) {
                 var ws_client = new WebSocket(jd + '/jobs/no-such-job');
                 ws_client.on('message', function(data) {
-                    data = JSON.parse(data);
+                    data = JSDP.deserialize(data);
                     expect(data).to.deep.equal({err: "No such job: no-such-job"});
                     done();
                 });
@@ -916,7 +923,7 @@ describe("Juttled Tests", function() {
                 .then(function(response) {
                     var ws_client = new WebSocket(jd + '/jobs/' + job_id);
                     ws_client.on('message', function(data) {
-                        data = JSON.parse(data);
+                        data = JSDP.deserialize(data);
                         expect(data).to.deep.equal({err: "No such job: " + job_id});
                         done();
                     });


### PR DESCRIPTION
Use JSDP to serialize messages sent from the juttle-subprocess to job-manager (which then get passed through to the websocket).

@mstemm

This may be going overboard with JSDP a bit by serializing everything juttle-subprocess sends and not just values from juttle itself, but job-manager just passes through everything it receives from the juttle-subprocess to the websocket. May want to look into creating a stricter separation between juttle-subprocess <-> job-manager and job-manager <-> websocket communication in the future.