### PR TITLE
Don't send redundant messages to subprocess.

### DIFF
--- a/lib/job-manager.js
+++ b/lib/job-manager.js
@@ -124,6 +124,11 @@ var JuttleJob = Base.extend({
             } else {
                 logger.debug("Subprocess exited with code=" + code);
             }
+
+            // Set _child to undefined now, so nothing can send it a
+            // message any longer.
+            self._child = undefined;
+
             self.job_stopped();
 
             self._endpoints.forEach(function(endpoint) {

--- a/lib/websocket-endpoint.js
+++ b/lib/websocket-endpoint.js
@@ -76,6 +76,8 @@ var WebsocketEndpoint = Base.extend({
 
         force = force || false;
 
+        logger.debug("close() called, force=" + force);
+
         // If there are any queued messages, wait for them to all be
         // sent first. Just set _closed to true. The end of drain()
         // will call close() again once the queue is empty.


### PR DESCRIPTION
There are cases where JuttleJob::close() can be legitimately called
multiple times:

 - When a job is being stopped internally (e.g. due to the program
   exiting).
 - When a job is being stopped externally (e.g. due to an explicit
   command to stop the job, or due to all websocket connections
   exiting for a job).

There isn't any harm from this happening, but I did notice these
errors in the logs that resulted from sending the spawned subprocess a
redundant 'end' message:

[2016-01-14 16:16:20.730] [DEBUG] demo-job-manager - Removing job 3a79b595-7e93-47bc-9764-5cd0ec216143 from jobs hash
[2016-01-14 16:16:20.730] [DEBUG] demo-job-manager - (job=3a79b595-7e93-47bc-9764-5cd0ec216143) Stopping job
[2016-01-14 16:16:20.731] [ERROR] demo-job-manager - Received error Error: channel closed from subprocess
[2016-01-14 16:16:21.652] [DEBUG] demo-job-manager - Removing job e8a09b3d-9b34-4bca-b0c7-306f16a1b536 from jobs hash
[2016-01-14 16:16:21.652] [DEBUG] demo-job-manager - (job=e8a09b3d-9b34-4bca-b0c7-306f16a1b536) Stopping job
[2016-01-14 16:16:21.653] [ERROR] demo-job-manager - Received error Error: channel closed from subprocess

Prevent the redundant messages from being sent by setting self._child
to undefined once the job manager receives a 'close'
event (indicating that the subprocess has exited).

The change to websocket-endpoint is just useful in helping understand what is going on.

This fixes #82.

@demmer @go-oleg @davidvgalbraith 