### PR TITLE
add a wrapper script to expose bin/juttle in an outrigger installation

### DIFF
--- a/bin/juttle
+++ b/bin/juttle
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+//
+// Simple helper script to expose the juttle CLI as part of an
+// outrigger installation.
+//
+var path = require('path');
+var juttle = path.resolve(__dirname, '../node_modules/juttle/bin/juttle');
+require(juttle)

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "license": "Apache-2.0",
   "bin": {
     "outriggerd": "bin/outriggerd",
-    "outrigger-client": "bin/outrigger-client"
+    "outrigger-client": "bin/outrigger-client",
+    "juttle": "bin/juttle"
   },
   "repository": "juttle/outrigger",
   "scripts": {


### PR DESCRIPTION
Include a simple `bin/juttle` script that resolves the local juttle
installation and then requires it. This way an installation of outrigger
will make it easy to run juttle CLI commands as well.