### PR TITLE
examples: update stock price example

### DIFF
--- a/examples/core-juttle/stock_prices.juttle
+++ b/examples/core-juttle/stock_prices.juttle
@@ -27,28 +27,27 @@ sub fetch(what) {
   | put time = date
 }
 
-function sanitizeValue(value) {
-  if (value == null) {
-    return 0;
-  } else {
-    return Number.fromString(value);
-  }
-}
-
 sub prices() {
   fetch -what 'd'
   | keep time, Close, Volume
   | split
   | reduce -forget false -every :d: value=last(value) by name
-  | put value = sanitizeValue(value)
-  | view timechart 
+  | (
+      filter name = 'Volume'
+      | put value = Number.fromString(value ?? "0");
+
+      filter name = 'Close'
+      | filter value != null
+      | put value = Number.fromString(value);
+    )
+  | view timechart
       -title '${symbol} closing price' -id 'chart'
       -display.dataDensity 0
       -keyField 'name'
       -valueField 'value'
       -series [
-        {name: 'Close', geom: 'line', yScale: 'primary'}, 
-        {name: 'Volume', geom: 'bars', yScale: 'secondary'} 
+        {name: 'Close', geom: 'line', yScale: 'primary'},
+        {name: 'Volume', geom: 'bars', yScale: 'secondary'}
     ];
 }
 


### PR DESCRIPTION

Tweak the juttle used to render the chart so that we treat the
price series differently from the volume series.

For the prices, simply remove any values that are null so the chart
appears as a continuous line instead of dropping down to zero each
time.

For the volume however, keep the old behavior that converted a null
to a zero value.

![screen shot 2016-01-18 at 11 20 32 am](https://cloud.githubusercontent.com/assets/3308504/12400537/8a355fc0-bdd5-11e5-85c0-3f504f050f8a.png)

@dmehra 