### PR TITLE
Add gmail adapter examples.

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -13,6 +13,7 @@ Examples                               | Special instructions
 [core-juttle](core-juttle/README.md)   | No special configuration; examples using http will need network connectivity
 [twitter-race](twitter-race/README.md) | To read from a twitter stream, you need to configure credentials in ``juttle-config.json`` file, see [README](twitter-race/README.md)
 [elastic-newstracker](elastic-newstracker/README.md) | To read from elasticsearch, this example needs to start additional docker containers, supply its yml file to ``docker-compose``
+[gmail](gmail/README.md) | To read from/write to gmail, you need to configure credentials in ``juttle-config.json`` file, see [README](gmail/README.md)
 
 If you wish to run all available examples, this command will start all necessary docker containers:
 

--- a/examples/gmail/README.md
+++ b/examples/gmail/README.md
@@ -1,0 +1,67 @@
+# Gmail
+
+These examples show ways to read messages from a gmail account and categorize the messages as well as writing the results of programs back to gmail by sending messages.
+
+A [detailed walkthrough](https://github.com/juttle/juttle-gmail-adapter/blob/master/docs/adapter_impl_notes.md) of the adapter implementation is available if you want to use it as a basis for writing your own adapters.
+
+## Additional docker-compose configuration
+
+None needed.
+
+## ``juttle-config.json`` configuration
+
+Modify `juttle-config.json` to add a ``juttle-gmail-adapter`` section containing credentials to access messages via the Gmail API:
+
+{
+  "adapters": {
+    "juttle-gmail-adapter": {
+      "client-credentials": {
+        "installed": {
+          "client_id": "--your-client-id--",
+          "project_id": "--your-project-id",
+          "auth_uri": "https:\/\/accounts.google.com\/o\/oauth2\/auth",
+          "token_uri": "https:\/\/accounts.google.com\/o\/oauth2\/token",
+          "auth_provider_x509_cert_url": "https:\/\/www.googleapis.com\/oauth2\/v1\/certs",
+          "client_secret": "--your-client-secret-id--",
+          "redirect_uris": [
+            "urn:ietf:wg:oauth:2.0:oob",
+            "http:\/\/localhost"
+          ]
+        }
+      },
+      "oauth2-token": {
+        "access_token": "---your-access-token---",
+        "token_type": "Bearer",
+        "refresh_token": "---your-refresh-token---",
+        "expiry_date": DDDDDDDDDDDDD
+      }
+    }
+  }
+}
+
+The full set of steps to generate these credentials is [on the README](https://github.com/juttle/juttle-gmail-adapter) page on github.
+
+## Juttle Programs
+
+To run any of these programs, just visit
+``http://(localhost|docker machine ip):8080/run?path=/examples/gmail/index.juttle``
+and follow the links.
+
+### Categorizing messages by recipient
+
+This program reads all messages from the last 12 hours, categorizes the messages by sender, and displays a table and bar chart with the counts. The gmail search expression is configurable.
+
+View this program: [messages_by_sender.juttle](./messages_by_sender.juttle)
+
+### Categorizing messages by time
+
+This program reads all messages from the last 12 hours, batches the messages by time received in 30 minute groups, and displays a timechart with the counts. This program shows how juttle field matches map to message properties by only selecting those messages sent specifically to "me" (i.e. the gmail account owner).
+
+View this program: [messages_by_time.juttle](./messages_by_time.juttle)
+
+### Writing results by sending messages
+
+This program emits a small set of artificial data and writes the result by sending an email. The email contains the data as a JSON attachment to the email. (The output is also written to a table so it can be viewed in outrigger).
+
+View this program: [write_results.juttle](./write_results.juttle)
+

--- a/examples/gmail/index.juttle
+++ b/examples/gmail/index.juttle
@@ -1,0 +1,10 @@
+sub add_juttle(name, description) {
+    put program="[" + name + "](/run?path=/examples/gmail/" + name + ".juttle)", description=description
+}
+
+emit |
+    ( add_juttle -name "messages_by_sender" -description 'Categorize gmail emails by sender';
+      add_juttle -name "messages_by_time" -description 'Categorize gmail emails by time';
+      add_juttle -name "write_results" -description 'Write program results by sending emails')
+    | keep program, description
+    | view table -title "Demo Juttle Programs" -markdownFields ['program']

--- a/examples/gmail/messages_by_sender.juttle
+++ b/examples/gmail/messages_by_sender.juttle
@@ -1,0 +1,7 @@
+input gmail_search: text -default "to:me" -label 'Gmail Filter';
+
+read gmail -from :12 hours ago: -to :now: -raw gmail_search
+    | reduce count() by from
+    | sort count -desc
+    | ( view table -title "Who sends the most mail?";
+        view barchart -title "Who sends the most mail?");

--- a/examples/gmail/messages_by_time.juttle
+++ b/examples/gmail/messages_by_time.juttle
@@ -1,0 +1,6 @@
+read gmail -from :12 hours ago: -to :now: to=~ "me"
+    | batch -every :30 minutes:
+    | reduce count()
+    | view timechart -title "When during the day do I get mail?" -yScales.primary.label "Number of Messages"
+
+

--- a/examples/gmail/write_results.juttle
+++ b/examples/gmail/write_results.juttle
@@ -1,0 +1,4 @@
+emit -limit 10
+    | (write gmail -subject "Example outrigger + gmail + write output";
+       view table);
+

--- a/examples/index.juttle
+++ b/examples/index.juttle
@@ -6,7 +6,8 @@ emit
 |(
     add_subdir_juttle -subdir "core-juttle" -juttle "index" -description "Examples of core juttle features";
     add_subdir_juttle -subdir "twitter-race" -juttle "twitter" -description "Examples using twitter adapter";
-    add_subdir_juttle -subdir "elastic-newstracker" -juttle "index" -description "Examples using elasticsearch adapter"
+    add_subdir_juttle -subdir "elastic-newstracker" -juttle "index" -description "Examples using elasticsearch adapter";
+    add_subdir_juttle -subdir "gmail" -juttle "index" -description "Examples using gmail adapter"
 )
 | keep program, description
 | view table -title 'Example Juttle Programs' -markdownFields [ 'program' ]

--- a/examples/twitter-race/README.md
+++ b/examples/twitter-race/README.md
@@ -10,7 +10,7 @@ None needed.
 
 ## ``juttle-config.json`` configuration
 
-Modify `juttle-config.json` to add a ``jutter-twitter-adapter`` section containing credentials to access twitter via API:
+Modify `juttle-config.json` to add a ``juttle-twitter-adapter`` section containing credentials to access twitter via API:
 
 ```
 {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "juttle": "^0.2.0",
     "juttle-client-library": "^0.1.0",
     "juttle-elastic-adapter": "^0.2.0",
-    "juttle-gmail-adapter": "^0.2.0",
+    "juttle-gmail-adapter": "^0.3.0",
     "juttle-graphite-adapter": "^0.2.0",
     "juttle-influx-adapter": "^0.2.0",
     "juttle-mysql-adapter": "^0.2.0",


### PR DESCRIPTION
Add a note to the top level README/index.juttle referring to the gmail directory.

In the gmail directory, add a index.juttle, a README.md, and 3 programs:

 - messages_by_sender: read the last 12 hours of messages and categorize by sender. You can specify any gmail search expression in an input.
 - messages_by_time: read the last 12 hours of messages sent to "me" and categorize by time received.
 - write_results: write some artificial data to gmail (i.e. send in an email).

Update outrigger to v0.3.0 of the gmail adapter so it has write support and support for filter expressions.

I also snuck in an unrelated change to fix a typo in the twitter README.

In order for these examples to work with the outrigger docker image,
I'll have to npm publish outrigger 0.4.0 and publish a new docker
image to pick up the juttle-gmail-adapter version. I'll do that
shortly after merging if not tomorrow.

This fixes #56.

@dmehra @go-oleg @demmer 