### PR TITLE
style select input for outrigger

### DIFF
--- a/src/apps/sass/juttle-client-library-overrides.scss
+++ b/src/apps/sass/juttle-client-library-overrides.scss
@@ -6,4 +6,22 @@
         color: $input-color;
         border-color: $input-border;
     }
+
+    .Select,
+    .Select.is-open,
+    .Select.has-value,
+    .Select.is-focused.is-pseudo-focused {
+        .Select-control,
+        .Select-control .Select-value .Select-value-label,
+        .Select-menu-outer,
+        .Select-option {
+            background-color: $input-bg;
+            color: $input-color;
+            border-color: $input-border;
+        }
+
+        .Select-option:hover {
+            background-color: $component-active-bg;
+        }
+    }
 }


### PR DESCRIPTION
Override the [react-select](https://github.com/JedWatson/react-select) styling that comes from juttle-client-library

![image](https://cloud.githubusercontent.com/assets/3344137/12435257/3b7b3c0a-bec1-11e5-8ee8-ed1f88e6964d.png)

@mnibecker 