### PR TITLE
Move read_config call after all require()s.

### DIFF
--- a/lib/juttle-subprocess.js
+++ b/lib/juttle-subprocess.js
@@ -44,7 +44,6 @@ var Juttle = require('juttle/lib/runtime').Juttle;
 // The only argument to this process is the path to the config
 // file. May not be provided, in which case a default set of search
 // paths will be used.
-var config = read_config({config_path: process.argv[2]});
 var compiler = require('juttle/lib/compiler');
 var optimize = require('juttle/lib/compiler/optimize');
 var views_sourceinfo = require('juttle/lib/compiler/flowgraph/views_sourceinfo');
@@ -53,6 +52,7 @@ var implicit_views = require('juttle/lib/compiler/flowgraph/implicit_views');
 var JSDP = require('juttle-jsdp');
 var JSDPValueConverter = require('./jsdp-value-converter');
 
+var config = read_config({config_path: process.argv[2]});
 Juttle.adapters.configure(config.adapters);
 
 var running_program;


### PR DESCRIPTION
Make sure that all require()s have been called before calling
read_config(). We ran into a problem where read_config, which
internally calls logger.debug() for one of the paths, may call the
juttle-subprocess.js's getLogger function, which depends on modules in
juttle-subprocess.js.

@demmer @go-oleg 