### PR TITLE
Add example program for npm download counts.

### DIFF
--- a/examples/core-juttle/README.md
+++ b/examples/core-juttle/README.md
@@ -64,4 +64,12 @@ This program showcases different charts (XXX/need to finish! Only tile shown rig
 
 View this program: [chart_gallery.juttle](./chart_gallery.juttle)
 
+### NPM Download Counts
+
+This program shows a timechart of [npm](https://www.npmjs.com/)
+download counts for a given npm package. The npm package is
+configurable via an input control.
+
+View this program: [npm_download_counts.juttle](./npm_download_counts.juttle)
+
 

--- a/examples/core-juttle/index.juttle
+++ b/examples/core-juttle/index.juttle
@@ -8,6 +8,7 @@ emit |
       add_juttle -name "fizzbuzz" -description 'Implementation of fizzbuzz algorithm';
       add_juttle -name "stock_prices" -description 'Show stock prices and events for a stock symbol';
       add_juttle -name "kitchen_duty" -description 'Find daily kitchen duty \"volunteers\"';
-      add_juttle -name "view_gallery" -description 'Sample of all views')
+      add_juttle -name "view_gallery" -description 'Sample of all views';
+      add_juttle -name "npm_download_counts" -description 'View NPM download counts over time')
     | keep program, description
     | view table -title "Demo Juttle Programs" -markdownFields ['program']

--- a/examples/core-juttle/npm_download_counts.juttle
+++ b/examples/core-juttle/npm_download_counts.juttle
@@ -1,0 +1,6 @@
+input npm_package: text -default "juttle";
+
+read http -url 'https://api.npmjs.org/downloads/range/last-month/${npm_package}' -timeField "day" -rootPath "downloads"
+    | put package=npm_package
+    | view timechart -keyField "package" -series [{name: npm_package, geom: 'bars'}] -yScales.primary.label "Number of NPM Downloads"
+


### PR DESCRIPTION
Now that we're using juttle 0.3.0, the http adapter supports -rootPath
to peek into json results. Use that for a new example program that
shows npm download counts.

This fixes #55.