### PR TITLE
Update to 0.2.1.

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "isomorphic-fetch": "^2.2.0",
     "jquery": "^2.1.4",
     "juttle": "^0.3.1",
-    "juttle-client-library": "^0.2.0",
+    "juttle-client-library": "^0.2.1",
     "juttle-elastic-adapter": "^0.3.0",
     "juttle-gmail-adapter": "^0.4.0",
     "juttle-graphite-adapter": "^0.3.0",


### PR DESCRIPTION
0.2.1 has fixes that ensure barcharts work properly so we want to use
at least 0.2.1, even though ^0.2.0 will pick up the latest version.

@go-oleg 