### PR TITLE
fixed tests to use find-free-port to avoid port collisions

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "chromedriver": "^2.20.0",
     "css-loader": "^0.23.0",
     "extract-text-webpack-plugin": "^0.9.1",
+    "find-free-port": "^1.0.2",
     "gulp": "^3.9.0",
     "gulp-eslint": "^1.1.1",
     "gulp-istanbul": "^0.10.3",

--- a/test/app/lib/outrigger-tester.js
+++ b/test/app/lib/outrigger-tester.js
@@ -3,6 +3,7 @@
 let _ = require('underscore');
 let expect = require('chai').expect;
 let Promise = require('bluebird');
+let findFreePort = Promise.promisify(require('find-free-port'));
 let retry = require('bluebird-retry');
 
 let webdriver = require('selenium-webdriver');
@@ -26,17 +27,19 @@ if (!nconf.get('SELENIUM_BROWSER')) {
 
 let JuttledService = require('../../../lib/service-juttled');
 
-const OUTRIGGER_PORT = 2000;
-
 class OutriggerTester {
     start(cb) {
-        this.outrigger = new JuttledService({
-            port: OUTRIGGER_PORT,
-            root_directory: '/'
-        }, cb);
+        findFreePort(10000, 20000)
+        .then((port) => {
+            this.port = port;
+            this.outrigger = new JuttledService({
+                port: port,
+                root_directory: '/'
+            }, cb);
 
-        this.driver = new webdriver.Builder()
-            .build();
+            this.driver = new webdriver.Builder()
+                .build();
+        });
     }
 
     stop() {
@@ -297,7 +300,7 @@ class OutriggerTester {
             return `${name}=${value}`;
         });
         var host = nconf.get('OUTRIGGER_HOST') || 'localhost';
-        return this.driver.get('http://' + host + ':' + OUTRIGGER_PORT +
+        return this.driver.get('http://' + host + ':' + this.port +
                                '/run?' + params.join('&'));
     }
 }


### PR DESCRIPTION
this will fix an issue that sometimes creeps up running tests locally
since we use the default 8080 port and as a developer you may have an
outriggerd instance already running.