### PR TITLE
jsdp-value-converter: add hack to handle infinite dates

### DIFF
--- a/lib/jsdp-value-converter.js
+++ b/lib/jsdp-value-converter.js
@@ -10,7 +10,13 @@ var dateConverter = {
         return _.isDate(value);
     },
     convertToJSDPValue: function(value) {
-        return value.moment.toDate();
+        // Currently, :beginning: and :end: are implemented in Juttle as
+        // hacky infinite moments that can't actually be wrapped in a Date.
+        // To avoid blowing up jsdp, convert them to the smallest/largest
+        // legal Date.
+        return value.isEnd() ? new Date(100000000 *  86400000) :
+               value.isBeginning() ? new Date(-100000000 * 86400000) :
+               value.moment.toDate();
     },
     convertToJuttleValue: function(value) {
         return new JuttleMoment({ rawDate: value });


### PR DESCRIPTION
The special moment values `:beginning:` and `:end:` are represented
internally as -Infinity and Infinity. While moment can (sort-of)
handle these, Date cannot, so outrigger blows up if one of these
values is used in the time range for read or in the points.

To work around this problem, convert infinite moments to the
smallest / largest legal Javascript date before encoding over
JSDP.