### PR TITLE
Don't close websocket connections immediately.

### DIFF
--- a/lib/ws-juttle-job.js
+++ b/lib/ws-juttle-job.js
@@ -27,8 +27,10 @@ var WebsocketJuttleJob = JuttleJob.extend({
         // When this job emits an 'end' event, the program has
         // completed, and we should close all websocket connections.
         self.events.on('end', function() {
-            self._endpoints.forEach(function(endpoint) {
-                endpoint.close();
+            setTimeout(function() {
+                self._endpoints.forEach(function(endpoint) {
+                    endpoint.close();
+                }, 10000);
             });
         });
     },
@@ -79,7 +81,8 @@ var WebsocketJuttleJob = JuttleJob.extend({
             if (self._job_stopped) {
                 logger.debug(self._log_prefix + 'Received job stopped, sending this endpoint a job_stopped message and closing');
                 endpoint.send(self._job_end_msg);
-                endpoint.close();
+                setTimeout(endpoint.close.bind(endpoint),
+                           10000);
                 return;
             }
         }

--- a/test/juttled/juttled.spec.js
+++ b/test/juttled/juttled.spec.js
@@ -1149,6 +1149,7 @@ describe('Juttled Tests', function() {
                     var num_ticks = 0;
                     var num_marks = 0;
                     var num_sink_ends = 0;
+                    var got_job_end_time = undefined;
                     ws_client = new WebSocket(juttleBaseUrl + '/jobs/' + job_id);
                     ws_client.on('message', function(data) {
                         //console.log("Got Websocket:", data);
@@ -1182,6 +1183,7 @@ describe('Juttled Tests', function() {
                                 }
                             ]);
                         } else if (data.type === 'job_end') {
+                            got_job_end_time = Date.now();
                             expect(data.job_id === job_id);
 
                             // Now check that we received all the ticks/marks/etc we expected.
@@ -1192,7 +1194,6 @@ describe('Juttled Tests', function() {
 
                             expect(num_marks).to.be.equal(6);
                             expect(num_sink_ends).to.equal(2);
-                            done();
                         } else if (data.type === 'tick') {
                             num_ticks++;
                             expect(data.sink_id).to.match(/view\d+/);
@@ -1221,6 +1222,19 @@ describe('Juttled Tests', function() {
                                 expect(data.points[0].val2).to.equal(30);
                             }
                         }
+                    });
+
+                    ws_client.on('close', function(data) {
+
+                        // There should be at least 1 second between
+                        // the job_end message and the websocket
+                        // closing. This shows that
+                        // delayed_websocket_close is actually
+                        // working.
+
+                        var got_ws_close_time = Date.now();
+                        expect(got_ws_close_time-got_job_end_time).to.be.at.least(1000);
+                        done();
                     });
                 });
         };


### PR DESCRIPTION
This is a fix for #131, taking parts of the fix from juttle-engine for
juttle/juttle-engine#9. I didn't bother with a fully configurable timeout.

I did copy over a unit test to ensure that there is a delay between
the job_end message and the websocket being closed.

Note that this PR is to merge to the 0.5.0 branch, which was based of off 0.5.0-rc.1.